### PR TITLE
feat: update kernel to 6.6.134

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-amd64_abiname=6.6.127
-arm64_abiname=6.6.127
-loong64_abiname=6.6.127
+amd64_abiname=6.6.134
+arm64_abiname=6.6.134
+loong64_abiname=6.6.134
 ARCH_BUILD :=$(shell uname -m)
 all: build
 build:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-deepin-hwe (6.6.134-1) unstable; urgency=medium
+
+  * update kernel to 6.6.134.
+
+ -- lichenggang <lichenggang@deepin.org>  Wed, 22 Apr 2026 16:20:00 +0800
+
 linux-deepin-hwe (6.6.127-2) unstable; urgency=medium
 
   * add Provides: linux-image-6.6.0-loong64-desktop Provides: linux-headers-6.6.0-loong64-desktop


### PR DESCRIPTION
更新内核版本到 6.6.134

## 变更内容
- 更新 Makefile 中的内核版本号 (6.6.127 → 6.6.134)
- 更新 debian/changelog 添加新版本记录

参考 PR: #32