### PR TITLE
feat: update kernel to 6.6.142

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-amd64_abiname=6.6.138
-arm64_abiname=6.6.138
-loong64_abiname=6.6.138
+amd64_abiname=6.6.142
+arm64_abiname=6.6.142
+loong64_abiname=6.6.142
 ARCH_BUILD :=$(shell uname -m)
 all: build
 build:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+linux-deepin-hwe (6.6.142-1) unstable; urgency=medium
+
+  * update kernel to 6.6.142.
+
+ -- lichenggang <lichenggang@deepin.org>  Tue, 02 Jun 2026 16:00:00 +0800
+
+
 linux-deepin-hwe (6.6.138-1) unstable; urgency=medium
 
   * update kernel to 6.6.138.


### PR DESCRIPTION
## Summary
- Update kernel version from 6.6.138 to 6.6.142 for all supported architectures (amd64, arm64, loong64)
- Update abiname in Makefile
- Add new changelog entry for version 6.6.142-1

## Test plan
1. Verify amd64 kernel package resolves to version 6.6.142
2. Verify arm64 kernel package resolves to version 6.6.142
3. Verify loong64 kernel package resolves to version 6.6.142
4. Confirm debian/changelog version bumped to 6.6.142-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)