### PR TITLE
feat: update kernel to 6.6.143

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-amd64_abiname=6.6.142
-arm64_abiname=6.6.142
-loong64_abiname=6.6.142
+amd64_abiname=6.6.143
+arm64_abiname=6.6.143
+loong64_abiname=6.6.143
 ARCH_BUILD :=$(shell uname -m)
 all: build
 build:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+linux-deepin-hwe (6.6.143-1) unstable; urgency=medium
+
+  * update kernel to 6.6.143.
+
+ -- lichenggang <lichenggang@deepin.org>  Mon, 22 Jun 2026 16:00:00 +0800
+
+
 linux-deepin-hwe (6.6.142-1) unstable; urgency=medium
 
   * update kernel to 6.6.142.


### PR DESCRIPTION
Update kernel version to 6.6.143 for all supported architectures This includes amd64, arm64, and loong64 kernel packages Update abiname in Makefile for all architectures
Add new changelog entry for version 6.6.143-1

Log: Update kernel to version 6.6.143

Influence:
1. Verify amd64 kernel package resolves to version 6.6.143
2. Verify arm64 kernel package resolves to version 6.6.143
3. Verify loong64 kernel package resolves to version 6.6.143
4. Confirm debian/changelog version bumped to 6.6.143-1

feat: 更新内核版本到 6.6.143

更新所有支持的架构的内核版本到 6.6.143
包括 amd64、arm64 和 loong64 内核包
更新 Makefile 中所有架构的 abiname
新增版本 6.6.143-1 的 changelog 条目

Log: 更新内核到 6.6.143 版本

Influence:
1. 验证 amd64 内核包版本正确解析为 6.6.143
2. 验证 arm64 内核包版本正确解析为 6.6.143
3. 验证 loong64 内核包版本正确解析为 6.6.143
4. 确认 debian/changelog 版本已提升至 6.6.143-1